### PR TITLE
Hotfix: 빌드를 위해 let -> const 수정

### DIFF
--- a/src/component/Button/Main.tsx
+++ b/src/component/Button/Main.tsx
@@ -7,7 +7,7 @@ const Main = () => {
 
   const download = () => {
     const { artist, imgSrc } = SHELFS[Number(router.id)];
-    let a = document.createElement("a");
+    const a = document.createElement("a");
     a.href = imgSrc;
     a.download = `${artist}_책가도`;
     a.click();


### PR DESCRIPTION
# 개요
빌드를 위해 let -> const 수정

# 상세 내용
- Button 하위의 Main에 사용되는 a 변수의 내용이 변경되지 않기 때문에, 기존 let으로 작업 시 빌드 오류 발생 => let -> const로 변경

# 비고