### PR TITLE
Fix: PC에서 click 이벤트 오류

### DIFF
--- a/src/component/Card.tsx
+++ b/src/component/Card.tsx
@@ -27,7 +27,7 @@ export const Card = ({
   };
 
   const handleClick = () => {
-    return isMobile ? moveTo() : null;
+    return isMobile ? null : moveTo();
   };
 
   const handleTouchStart = (e: React.TouchEvent) => {

--- a/src/hook/useIsMobile.ts
+++ b/src/hook/useIsMobile.ts
@@ -13,7 +13,7 @@ const useIsMobile = () => {
     return () => window.removeEventListener("resize", handleInner);
   }, []);
 
-  return inner < MOBILE_WIDTH;
+  return inner > 0 && inner < MOBILE_WIDTH;
 };
 
 export default useIsMobile;


### PR DESCRIPTION
# 개요
PC에서 click 이벤트 오류

# 상세 내용
- PC에서 카드를 클릭하면 상세 페이지로 이동, Mobile에서는 아래로 스와이프 해야 이동해야했으나, 조건문이 잘못되어 반대로 적용된 현상 수정

# 비고